### PR TITLE
fix: add check if runtime is null and change error message; add tests

### DIFF
--- a/bootique-cayenne-junit5/pom.xml
+++ b/bootique-cayenne-junit5/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>bootique-jdbc-junit5-derby</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.7.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Optional profile used to sign artifacts -->

--- a/bootique-cayenne-junit5/src/main/java/io/bootique/cayenne/junit5/CayenneTester.java
+++ b/bootique-cayenne-junit5/src/main/java/io/bootique/cayenne/junit5/CayenneTester.java
@@ -245,7 +245,9 @@ public class CayenneTester implements BQBeforeScopeCallback, BQBeforeMethodCallb
     }
 
     protected void resolveRuntimeManager(ServerRuntime runtime) {
-
+        if(runtime == null) {
+            throw new RuntimeException("Cayenne tester not linked to any BQRuntime!");
+        }
         if (allTables) {
             this.runtimeManager = CayenneRuntimeManager
                     .builder(runtime.getDataDomain())

--- a/bootique-cayenne-junit5/src/test/java/io/bootique/cayenne/junit5/CayenneTester_NoRuntimeConnectedIT.java
+++ b/bootique-cayenne-junit5/src/test/java/io/bootique/cayenne/junit5/CayenneTester_NoRuntimeConnectedIT.java
@@ -1,0 +1,75 @@
+package io.bootique.cayenne.junit5;
+
+import io.bootique.junit5.BQTest;
+import io.bootique.junit5.BQTestTool;
+import io.bootique.junit5.handler.testtool.BQTestToolHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+@BQTest
+public class CayenneTester_NoRuntimeConnectedIT {
+
+    @ExtendWith(BQTestToolHandler.class)
+    static class TesterProvider{
+        @BQTestTool
+        CayenneTester ct = CayenneTester.create();
+
+        public CayenneTester getCt() {
+            return ct;
+        }
+
+        @Test
+        void testMethod(){}
+    }
+
+    @Test
+    public void testCayenneTesterInitialization(){
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(TesterProvider.class))
+                .build();
+
+        final org.junit.platform.launcher.Launcher launcher = LauncherFactory.create();
+        final SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        final ThrowableCatchingListener throwableCatchingListener = new ThrowableCatchingListener();
+
+        launcher.registerTestExecutionListeners(listener, throwableCatchingListener);
+        launcher.execute(request);
+        TestExecutionSummary summary = listener.getSummary();
+        Assertions.assertEquals(1, summary.getTestsFailedCount());
+        List<Throwable> throwableList = throwableCatchingListener.getThrowableList();
+        for(Throwable throwable:throwableList){
+            Assertions.assertEquals("Cayenne tester not linked to any BQRuntime!", throwable.getMessage());
+        }
+    }
+
+
+    private class ThrowableCatchingListener implements TestExecutionListener{
+        private final List<Throwable> throwableList = new ArrayList<>();
+
+        @Override
+        public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+            TestExecutionListener.super.executionFinished(testIdentifier, testExecutionResult);
+            Optional<Throwable> throwable = testExecutionResult.getThrowable();
+            throwable.ifPresent(throwableList::add);
+        }
+
+        public List<Throwable> getThrowableList() {
+            return throwableList;
+        }
+    }
+}

--- a/bootique-cayenne41-junit5/pom.xml
+++ b/bootique-cayenne41-junit5/pom.xml
@@ -77,6 +77,19 @@
             <artifactId>bootique-jdbc-junit5-derby</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.7.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <!-- Optional profile used to sign artifacts -->

--- a/bootique-cayenne41-junit5/src/main/java/io/bootique/cayenne/v41/junit5/CayenneTester.java
+++ b/bootique-cayenne41-junit5/src/main/java/io/bootique/cayenne/v41/junit5/CayenneTester.java
@@ -45,7 +45,6 @@ import java.util.function.Consumer;
  * @since 2.0
  */
 public class CayenneTester implements BQBeforeScopeCallback, BQBeforeMethodCallback {
-
     private boolean refreshCayenneCaches;
     private boolean deleteBeforeEachTest;
     private boolean skipSchemaCreation;
@@ -256,7 +255,9 @@ public class CayenneTester implements BQBeforeScopeCallback, BQBeforeMethodCallb
     }
 
     protected void resolveRuntimeManager(ServerRuntime runtime) {
-
+        if(runtime == null) {
+            throw new RuntimeException("Cayenne tester not linked to any BQRuntime!");
+        }
         if (allTables) {
             this.runtimeManager = CayenneRuntimeManager
                     .builder(runtime.getDataDomain())

--- a/bootique-cayenne41-junit5/src/test/java/io/bootique/cayenne/v41/junit5/CayenneTester_NoRuntimeConnectedIT.java
+++ b/bootique-cayenne41-junit5/src/test/java/io/bootique/cayenne/v41/junit5/CayenneTester_NoRuntimeConnectedIT.java
@@ -1,0 +1,75 @@
+package io.bootique.cayenne.v41.junit5;
+
+import io.bootique.junit5.BQTest;
+import io.bootique.junit5.BQTestTool;
+import io.bootique.junit5.handler.testtool.BQTestToolHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+@BQTest
+public class CayenneTester_NoRuntimeConnectedIT {
+
+    @ExtendWith(BQTestToolHandler.class)
+    static class TesterProvider{
+        @BQTestTool
+        CayenneTester ct = CayenneTester.create();
+
+        public CayenneTester getCt() {
+            return ct;
+        }
+
+        @Test
+        void testMethod(){}
+    }
+
+    @Test
+    public void testCayenneTesterInitialization(){
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(TesterProvider.class))
+                .build();
+
+        final org.junit.platform.launcher.Launcher launcher = LauncherFactory.create();
+        final SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        final ThrowableCatchingListener throwableCatchingListener = new ThrowableCatchingListener();
+
+        launcher.registerTestExecutionListeners(listener, throwableCatchingListener);
+        launcher.execute(request);
+        TestExecutionSummary summary = listener.getSummary();
+        Assertions.assertEquals(1, summary.getTestsFailedCount());
+        List<Throwable> throwableList = throwableCatchingListener.getThrowableList();
+        for(Throwable throwable:throwableList){
+            Assertions.assertEquals("Cayenne tester not linked to any BQRuntime!", throwable.getMessage());
+        }
+    }
+
+
+    private class ThrowableCatchingListener implements TestExecutionListener{
+        private final List<Throwable> throwableList = new ArrayList<>();
+
+        @Override
+        public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+            TestExecutionListener.super.executionFinished(testIdentifier, testExecutionResult);
+            Optional<Throwable> throwable = testExecutionResult.getThrowable();
+            throwable.ifPresent(throwableList::add);
+        }
+
+        public List<Throwable> getThrowableList() {
+            return throwableList;
+        }
+    }
+}

--- a/bootique-cayenne42-junit5/pom.xml
+++ b/bootique-cayenne42-junit5/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>bootique-jdbc-junit5-derby</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.7.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Optional profile used to sign artifacts -->

--- a/bootique-cayenne42-junit5/src/main/java/io/bootique/cayenne/v42/junit5/CayenneTester.java
+++ b/bootique-cayenne42-junit5/src/main/java/io/bootique/cayenne/v42/junit5/CayenneTester.java
@@ -246,7 +246,9 @@ public class CayenneTester implements BQBeforeScopeCallback, BQBeforeMethodCallb
     }
 
     protected void resolveRuntimeManager(ServerRuntime runtime) {
-
+        if(runtime == null) {
+            throw new RuntimeException("Cayenne tester not linked to any BQRuntime!");
+        }
         if (allTables) {
             this.runtimeManager = CayenneRuntimeManager
                     .builder(runtime.getDataDomain())

--- a/bootique-cayenne42-junit5/src/test/java/io/bootique/cayenne/v42/junit5/CayenneTester_NoRuntimeConnectedIT.java
+++ b/bootique-cayenne42-junit5/src/test/java/io/bootique/cayenne/v42/junit5/CayenneTester_NoRuntimeConnectedIT.java
@@ -1,0 +1,75 @@
+package io.bootique.cayenne.v42.junit5;
+
+import io.bootique.junit5.BQTest;
+import io.bootique.junit5.BQTestTool;
+import io.bootique.junit5.handler.testtool.BQTestToolHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+@BQTest
+public class CayenneTester_NoRuntimeConnectedIT {
+
+    @ExtendWith(BQTestToolHandler.class)
+    static class TesterProvider{
+        @BQTestTool
+        CayenneTester ct = CayenneTester.create();
+
+        public CayenneTester getCt() {
+            return ct;
+        }
+
+        @Test
+        void testMethod(){}
+    }
+
+    @Test
+    public void testCayenneTesterInitialization(){
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(TesterProvider.class))
+                .build();
+
+        final org.junit.platform.launcher.Launcher launcher = LauncherFactory.create();
+        final SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        final ThrowableCatchingListener throwableCatchingListener = new ThrowableCatchingListener();
+
+        launcher.registerTestExecutionListeners(listener, throwableCatchingListener);
+        launcher.execute(request);
+        TestExecutionSummary summary = listener.getSummary();
+        Assertions.assertEquals(1, summary.getTestsFailedCount());
+        List<Throwable> throwableList = throwableCatchingListener.getThrowableList();
+        for(Throwable throwable:throwableList){
+            Assertions.assertEquals("Cayenne tester not linked to any BQRuntime!", throwable.getMessage());
+        }
+    }
+
+
+    private class ThrowableCatchingListener implements TestExecutionListener{
+        private final List<Throwable> throwableList = new ArrayList<>();
+
+        @Override
+        public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+            TestExecutionListener.super.executionFinished(testIdentifier, testExecutionResult);
+            Optional<Throwable> throwable = testExecutionResult.getThrowable();
+            throwable.ifPresent(throwableList::add);
+        }
+
+        public List<Throwable> getThrowableList() {
+            return throwableList;
+        }
+    }
+}


### PR DESCRIPTION
#87 
- Replace NullPointerException with custom RuntimeException
- Add tests for error message which will be generated
- Add necessary dependencies for dynamic tests running